### PR TITLE
Changed table drop order in down function of create_bouncer_tables migration

### DIFF
--- a/migrations/create_bouncer_tables.php
+++ b/migrations/create_bouncer_tables.php
@@ -70,10 +70,10 @@ class CreateBouncerTables extends Migration
      */
     public function down()
     {
-        Schema::drop('abilities');
-        Schema::drop('roles');
         Schema::drop('user_roles');
         Schema::drop('user_abilities');
         Schema::drop('role_abilities');
+        Schema::drop('abilities');
+        Schema::drop('roles');
     }
 }


### PR DESCRIPTION
I was running into a bit of trouble rolling back this migration. It turns out the tables with the foreign key constraints need to be dropped first. I changed around the order so the down method now works properly.

Awesome plugin! :+1: 