### PR TITLE
Adding readability methods "not" and necessary tests

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -218,10 +218,19 @@ The bouncer can check if a user has a specific role:
 Bouncer::is($user)->a('moderator');
 ```
 
+For readability, you can also check if a user doesn't have a specific role:
+
+```php
+Bouncer::is($user)->notA('moderator');
+```
+
 If the role you're checking starts with a vowel, you might want to use the `an` alias method:
 
 ```php
 Bouncer::is($user)->an('admin');
+
+// Inverse
+Bouncer::is($user)->notAn('admin');
 ```
 
 You can check if a user has one of many roles:
@@ -236,12 +245,20 @@ You can also check if the user has all of the given roles:
 Bouncer::is($user)->all('editor', 'moderator');
 ```
 
+You can also check if a user has none of the given roles:
+
+```php
+Bouncer::is($user)->notAn('editor', 'moderator');
+```
+
 These checks can also be done directly on the user:
 
 ```php
 $user->is('admin');
 
 $user->isAll('editor', 'moderator');
+
+$user->isNotAn('admin');
 ```
 
 ### Getting all abilities for a user
@@ -346,6 +363,10 @@ $check = Bouncer::is($user)->an('admin');
 $check = Bouncer::is($user)->a('moderator', 'editor');
 $check = Bouncer::is($user)->all('moderator', 'editor');
 
+$check = Bouncer::is($user)->notA('subscriber');
+$check = Bouncer::is($user)->notAn('admin');
+$check = Bouncer::is($user)->notAn('admin', 'editor');
+
 $check = Bouncer::allows('ban-users');
 $check = Bouncer::allows('edit', Post::class);
 $check = Bouncer::allows('delete', $post);
@@ -379,6 +400,9 @@ $user->retract('admin');
 $check = $user->is('subscriber');
 $check = $user->is('moderator', 'editor');
 $check = $user->isAll('moderator', 'editor');
+
+$check = $user->isNotA('subscriber');
+$check = $user->isNotAn('editor', 'moderator');
 
 $abilities = $user->getAbilities();
 ```

--- a/src/Clipboard.php
+++ b/src/Clipboard.php
@@ -82,6 +82,9 @@ class Clipboard
         if ($boolean == 'or') {
             return $available->count() > 0;
         }
+        elseif ($boolean === 'not') {
+            return $available->count() === 0;
+        }
 
         return $available->count() == count((array) $roles);
     }

--- a/src/Conductors/ChecksRole.php
+++ b/src/Conductors/ChecksRole.php
@@ -47,6 +47,19 @@ class ChecksRole
     }
 
     /**
+     * Check if the user doesn't have any of the given roles.
+     *
+     * @param  string  $role
+     * @return bool
+     */
+    public function notA($role)
+    {
+        $roles = func_get_args();
+
+        return $this->clipboard->checkRole($this->user, $roles, 'not');
+    }
+
+    /**
      * Alias to the "a" method.
      *
      * @param  string  $role
@@ -57,6 +70,19 @@ class ChecksRole
         $roles = func_get_args();
 
         return $this->clipboard->checkRole($this->user, $roles, 'or');
+    }
+
+    /**
+     * Alias to the "notA" method.
+     *
+     * @param  string  $role
+     * @return bool
+     */
+    public function notAn($role)
+    {
+        $roles = func_get_args();
+
+        return $this->clipboard->checkRole($this->user, $roles, 'not');
     }
 
     /**

--- a/src/Database/HasRolesAndAbilities.php
+++ b/src/Database/HasRolesAndAbilities.php
@@ -111,6 +111,36 @@ trait HasRolesAndAbilities
     }
 
     /**
+     * Check if the user has none of the given roles.
+     *
+     * @param  string  $role
+     * @return bool
+     */
+    public function isNotA($role)
+    {
+        $roles = func_get_args();
+
+        $clipboard = $this->getClipboardInstance();
+
+        return $clipboard->checkRole($this, $roles, 'not');
+    }
+
+    /**
+     * Alias of "isNotA" method.
+     *
+     * @param  string  $role
+     * @return bool
+     */
+    public function isNotAn($role)
+    {
+        $roles = func_get_args();
+
+        $clipboard = $this->getClipboardInstance();
+
+        return $clipboard->checkRole($this, $roles, 'not');
+    }
+
+    /**
      * Check if the user has all of the given roles.
      *
      * @param  string  $role

--- a/tests/BouncerSimpleTest.php
+++ b/tests/BouncerSimpleTest.php
@@ -82,11 +82,18 @@ class BouncerSimpleTest extends BaseTestCase
     {
         $bouncer = $this->bouncer($user = User::create());
 
+        $this->assertTrue($bouncer->is($user)->notA('moderator'));
+        $this->assertTrue($bouncer->is($user)->notAn('editor'));
+        $this->assertFalse($bouncer->is($user)->an('admin'));
+
+        $bouncer = $this->bouncer($user = User::create());
+
         $bouncer->assign('moderator')->to($user);
         $bouncer->assign('editor')->to($user);
 
         $this->assertTrue($bouncer->is($user)->a('moderator'));
         $this->assertTrue($bouncer->is($user)->an('editor'));
+        $this->assertFalse($bouncer->is($user)->notAn('editor'));
         $this->assertFalse($bouncer->is($user)->an('admin'));
     }
 
@@ -94,12 +101,17 @@ class BouncerSimpleTest extends BaseTestCase
     {
         $bouncer = $this->bouncer($user = User::create());
 
+        $this->assertTrue($bouncer->is($user)->notAn('editor', 'moderator'));
+        $this->assertTrue($bouncer->is($user)->notAn('admin', 'moderator'));
+
+        $bouncer = $this->bouncer($user = User::create());
         $bouncer->assign('moderator')->to($user);
         $bouncer->assign('editor')->to($user);
 
         $this->assertTrue($bouncer->is($user)->a('subscriber', 'moderator'));
         $this->assertTrue($bouncer->is($user)->an('admin', 'editor'));
         $this->assertTrue($bouncer->is($user)->all('editor', 'moderator'));
+        $this->assertFalse($bouncer->is($user)->notAn('editor', 'moderator'));
         $this->assertFalse($bouncer->is($user)->all('admin', 'moderator'));
     }
 

--- a/tests/HasRolesAndAbilitiesTraitTest.php
+++ b/tests/HasRolesAndAbilitiesTraitTest.php
@@ -50,11 +50,15 @@ class HasRolesAndAbilitiesTraitTest extends BaseTestCase
     {
         $gate = $this->gate($user = User::create());
 
+        $this->assertTrue($user->isNotA('moderator'));
+        $this->assertTrue($user->isNotAn('editor'));
+
         $user->assign('moderator');
         $user->assign('editor');
 
         $this->assertTrue($user->is('moderator'));
         $this->assertTrue($user->is('editor'));
+        $this->assertFalse($user->isNotAn('editor'));
         $this->assertFalse($user->is('admin'));
     }
 
@@ -62,12 +66,18 @@ class HasRolesAndAbilitiesTraitTest extends BaseTestCase
     {
         $gate = $this->gate($user = User::create());
 
+        $this->assertTrue($user->isNotA('moderator', 'admin'));
+        $this->assertTrue($user->isNotAn('editor', 'moderator'));
+        $this->assertTrue($user->isNotAn('editor', 'moderator'));
+
         $user->assign('moderator');
         $user->assign('editor');
 
         $this->assertTrue($user->is('moderator', 'admin'));
         $this->assertTrue($user->is('editor', 'moderator'));
+        $this->assertFalse($user->isNotAn('editor', 'moderator'));
         $this->assertTrue($user->isAll('editor', 'moderator'));
         $this->assertFalse($user->isAll('admin', 'moderator'));
+        $this->assertFalse($user->isNotAn('editor', 'moderator'));
     }
 }


### PR DESCRIPTION
This is a great package with excellent readability. In view of that, I've added some syntactic sugar to enhance the times when a user _doesn't_ have a particular role.

i.e.
```
if ($user->isNot('admin')) {
...
}
```
vs.
```
if (!$user->is('admin')) {
...
}
```

Like I said, simply some syntactic sugar. Also added some tests in.