### PR TITLE
Updating Gate import to use the contract

### DIFF
--- a/src/Middleware/Authorize.php
+++ b/src/Middleware/Authorize.php
@@ -3,7 +3,7 @@
 namespace Silber\Bouncer\Middleware;
 
 use Closure;
-use Illuminate\Auth\Access\Gate;
+use Illuminate\Contracts\Auth\Access\Gate;
 
 class Authorize
 {


### PR DESCRIPTION
The IOC binding in Laravel uses the contract.  Currently this results in a:

```
Illuminate\Contracts\Container\BindingResolutionException: Unresolvable dependency resolving [Parameter #1 [ <required> callable $userResolver ]] in class Illuminate\Auth\Access\Gate
```

Updating the import to utilize the contract allows the class to be correctly loaded out of the IOC container.