### PR TITLE
Fixes #103 Issue with Cache

### DIFF
--- a/src/CachedClipboard.php
+++ b/src/CachedClipboard.php
@@ -72,7 +72,10 @@ class CachedClipboard extends Clipboard
     {
         $key = $this->getCacheKey($authority, 'abilities');
 
-        if ($abilities = $this->cache->get($key)) {
+        $abilities = $this->cache->get($key);
+
+        if (is_array($abilities)) {
+
             return $this->deserializeAbilities($abilities);
         }
 


### PR DESCRIPTION
The cache might return null (if the key doesn't exist) or an empty array (if the user doesn't have abilities). This change allows the getAbilitiesMethod to return an empty array from the cache in order to prevent multiple queries if the user doesn't have abilities.