### PR TITLE
Allowing Models with uuids as primary key

### DIFF
--- a/migrations/create_bouncer_tables.php
+++ b/migrations/create_bouncer_tables.php
@@ -18,7 +18,7 @@ class CreateBouncerTables extends Migration
             $table->increments('id');
             $table->string('name');
             $table->string('title')->nullable();
-            $table->integer('entity_id')->unsigned()->nullable();
+            $table->string('entity_id')->nullable();
             $table->string('entity_type')->nullable();
             $table->timestamps();
 


### PR DESCRIPTION
Sometimes models could have a not integer type primary key, for instance uuids