### PR TITLE
Modified publishing migrations tag

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -88,7 +88,7 @@ class User extends Model
 4) Now, to run the bouncer's migrations, first publish the package's migrations into your app's `migrations` directory, by running the following command:
 
 ```
-php artisan vendor:publish --provider="Silber\Bouncer\BouncerServiceProvider" --tag="migrations"
+php artisan vendor:publish --tag="bouncer.migrations"
 ```
 
 5) Finally, run the migrations:

--- a/src/BouncerServiceProvider.php
+++ b/src/BouncerServiceProvider.php
@@ -144,7 +144,7 @@ class BouncerServiceProvider extends ServiceProvider
 
         $target = $this->app->databasePath().'/migrations/'.$timestamp.'_create_bouncer_tables.php';
 
-        $this->publishes([$stub => $target], 'migrations');
+        $this->publishes([$stub => $target], 'bouncer.migrations');
     }
 
     /**


### PR DESCRIPTION
I find this much easier:

``` bash
$ php artisan vendor:publish --tag=bouncer.migrations
```

On an unrelated note: if I want to use 'groups' as well (e.g.: a user can have an ability because it either is member of a group or has a certain role) can I use this package without forking it?