### PR TITLE
Fix setting custom owner field for model

### DIFF
--- a/src/Database/Models.php
+++ b/src/Database/Models.php
@@ -144,7 +144,7 @@ class Models
             static::$ownership['*'] = $model;
         }
 
-        static::$ownership[$model] = $attribute;
+        static::$ownership[strtolower(static::basename($model))] = $attribute;
     }
 
     /**


### PR DESCRIPTION
For App\SomeModel::class method isOwnedBy looks for "somemodel" key in ownership array but when we define custom ownership attribute via ownedVia method there is "App\SomeModel" instead of "somemodel"