### PR TITLE
$model string|Model throws an error on string comparition

### DIFF
--- a/src/Clipboard.php
+++ b/src/Clipboard.php
@@ -196,7 +196,7 @@ class Clipboard implements ClipboardContract
      */
     protected function compileModelAbilityIdentifiers($ability, $model)
     {
-        if ($model == '*') {
+        if (is_string($model) && $model == '*') {
             return ["{$ability}-*", "*-*"];
         }
 

--- a/src/Database/Concerns/IsAbility.php
+++ b/src/Database/Concerns/IsAbility.php
@@ -38,7 +38,7 @@ trait IsAbility
             $attributes = ['name' => $attributes];
         }
 
-        if ($model == '*') {
+        if (is_string($model) && $model == '*') {
             return (new static)->forceFill($attributes + [
                 'entity_type' => '*',
             ]);

--- a/src/Database/Queries/AbilitiesForModel.php
+++ b/src/Database/Queries/AbilitiesForModel.php
@@ -33,7 +33,7 @@ class AbilitiesForModel
      */
     public function constrain($query, $model, $strict = false)
     {
-        if ($model == '*') {
+        if (is_string($model) && $model == '*') {
             return $this->constrainByWildcard($query, $strict);
         }
 


### PR DESCRIPTION
FatalErrorException in AbilitiesForModel.php line 0:
Method App\Models\<Entity>::__toString() must not throw an exception