### PR TITLE
Adds allowing multiple abilities at once

### DIFF
--- a/src/Conductors/Concerns/AssociatesAbilities.php
+++ b/src/Conductors/Concerns/AssociatesAbilities.php
@@ -40,6 +40,13 @@ trait AssociatesAbilities
         }
 
         if ( ! is_null($model)) {
+            if (is_array($abilities)) {
+                $result = [];
+                foreach ($abilities as $ability) {
+                    $result[] = $this->getModelAbility($ability, $model, $attributes)->getKey();
+                }
+                return $result;
+            }
             return [$this->getModelAbility($abilities, $model, $attributes)->getKey()];
         }
 

--- a/tests/MultipleAbilitiesTest.php
+++ b/tests/MultipleAbilitiesTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class AbilitiesForModelsTest extends BaseTestCase
+class MultipleAbilitiesTest extends BaseTestCase
 {
 
     public $report = false;

--- a/tests/MultipleAbilitiesTest.php
+++ b/tests/MultipleAbilitiesTest.php
@@ -1,0 +1,95 @@
+<?php
+
+class AbilitiesForModelsTest extends BaseTestCase
+{
+
+    public $report = false;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        if($this->report) {
+            $this->db()->connection()->enableQueryLog();
+        }
+    }
+
+    public function tearDown()
+    {
+        if($this->report) {
+            var_dump($this->getName().': '.count($this->db()->connection()->getQueryLog()));
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_control_behaviour()
+    {
+        $user = User::create();
+
+        $bouncer = $this->bouncer($user)->dontCache();
+
+        $bouncer->allow($user)->to('edit');
+        $bouncer->allow($user)->to('delete');
+
+        $this->assertTrue($bouncer->allows('edit'));
+        $this->assertTrue($bouncer->allows('delete'));
+
+        $bouncer->disallow($user)->to('edit');
+
+        $this->assertTrue($bouncer->denies('edit'));
+        $this->assertTrue($bouncer->allows('delete'));
+    }
+
+    public function test_control_behaviour_with_model_reference()
+    {
+        $user = User::create();
+
+        $bouncer = $this->bouncer($user)->dontCache();
+
+        $bouncer->allow($user)->to('edit', User::class);
+        $bouncer->allow($user)->to('delete', User::class);
+
+        $this->assertTrue($bouncer->allows('edit', User::class));
+        $this->assertTrue($bouncer->allows('delete', User::class));
+
+        $bouncer->disallow($user)->to('edit', User::class);
+
+        $this->assertTrue($bouncer->denies('edit', User::class));
+        $this->assertTrue($bouncer->allows('delete', User::class));
+    }
+
+    public function test_multiple_abilties()
+    {
+        $user = User::create();
+
+        $bouncer = $this->bouncer($user)->dontCache();
+
+        $bouncer->allow($user)->to(['edit', 'delete']);
+
+        $this->assertTrue($bouncer->allows('edit'));
+        $this->assertTrue($bouncer->allows('delete'));
+
+        $bouncer->disallow($user)->to('edit');
+
+        $this->assertTrue($bouncer->denies('edit'));
+        $this->assertTrue($bouncer->allows('delete'));
+    }
+
+    public function test_multiple_abilties_with_model_reference()
+    {
+        $user = User::create();
+
+        $bouncer = $this->bouncer($user)->dontCache();
+
+        $bouncer->allow($user)->to(['edit', 'delete'], User::class);
+
+        $this->assertTrue($bouncer->allows('edit', User::class));
+        $this->assertTrue($bouncer->allows('delete', User::class));
+
+        $bouncer->disallow($user)->to('edit', User::class);
+
+        $this->assertTrue($bouncer->denies('edit', User::class));
+        $this->assertTrue($bouncer->allows('delete', User::class));
+    }
+}


### PR DESCRIPTION
It appeared to be not very difficult. Don't know if you like how it looks at the moment, but it works. Adding multiple abilities was already possible if you don't refer to a model.

I have added a separate test file. If you set `$report` to true, it will tell for each function the number of queries that have ran.
The two control tests execute 19 queries. The function adding multiple abilities without a reference model executes 16 queries, while the one with model reference executes 17 queries.