### PR TITLE
Update dependencies for laravel 5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "illuminate/auth": "5.1.20 - 5.4",
         "illuminate/container": "5.1.20 - 5.4",
         "illuminate/contracts": "5.1.20 - 5.4",
-        "illuminate/database": "5.1.20 - 5.4"
+        "illuminate/database": "5.1.20 - 5.5"
     },
     "require-dev": {
         "illuminate/cache": "5.1.20 - 5.4",

--- a/composer.json
+++ b/composer.json
@@ -26,14 +26,14 @@
         "classmap": ["tests"]
     },
     "require": {
-        "illuminate/auth": "5.1.20 - 5.4",
-        "illuminate/container": "5.1.20 - 5.4",
-        "illuminate/contracts": "5.1.20 - 5.4",
+        "illuminate/auth": "5.1.20 - 5.5",
+        "illuminate/container": "5.1.20 - 5.5",
+        "illuminate/contracts": "5.1.20 - 5.5",
         "illuminate/database": "5.1.20 - 5.5"
     },
     "require-dev": {
-        "illuminate/cache": "5.1.20 - 5.4",
-        "illuminate/console": "5.1.20 - 5.4",
+        "illuminate/cache": "5.1.20 - 5.5",
+        "illuminate/console": "5.1.20 - 5.5",
         "mockery/mockery": "^0.9.5",
         "phpunit/phpunit": "^4.8.35"
     },


### PR DESCRIPTION
update depencies

```"illuminate/auth": "5.1.20 - 5.5",
illuminate/container": "5.1.20 - 5.5",
"illuminate/contracts": "5.1.20 - 5.5",
"illuminate/database": "5.1.20 - 5.5"
"illuminate/cache": "5.1.20 - 5.5",
"illuminate/console": "5.1.20 - 5.5",