### PR TITLE
Add ownedViaMorph method

### DIFF
--- a/src/Database/Models.php
+++ b/src/Database/Models.php
@@ -157,7 +157,7 @@ class Models
      */
     public static function ownedViaMorph($model, $attribute)
     {
-        static::$ownership[$model] = function($model, $authority) use($attribute){
+        static::$ownership[$model] = function ($model, $authority) use ($attribute) {
             if ($model->{"{$attribute}_id"} !== $authority->id) {
                 return false;
             }

--- a/src/Database/Models.php
+++ b/src/Database/Models.php
@@ -162,7 +162,7 @@ class Models
                 return false;
             }
             
-            if ($model->{"{$attribute}_type"} !== get_class($model)) {
+            if ($model->{"{$attribute}_type"} !== get_class($authority)) {
                 return false;
             }
             

--- a/src/Database/Models.php
+++ b/src/Database/Models.php
@@ -147,6 +147,28 @@ class Models
 
         static::$ownership[$model] = $attribute;
     }
+    
+    /**
+     * Register a callback to determine if a model is owned by a given authority as a morph.
+     *
+     * @param  string  $model
+     * @param  string  $attribute
+     * @return void
+     */
+    public static function ownedViaMorph($model, $attribute)
+    {
+        static::$ownership[$model] = function($model, $authority) use($attribute){
+            if ($model->{"{$attribute}_id"} !== $authority->id) {
+                return false;
+            }
+            
+            if ($model->{"{$attribute}_type"} !== get_class($model)) {
+                return false;
+            }
+            
+            return true;
+        };
+    }
 
     /**
      * Determines whether the given model is owned by the given authority.


### PR DESCRIPTION
Just a shortcut to register a callback to check the standard morph attributes.

Where is this useful? Well think of Laravels in built notifications and you want the user to be able to manage their own notifications, delete them etc - it's a polymorphic relationship as things other than a User can be notified - so we need to check both columns.

```php
\Bouncer::ownedViaMorph(DatabaseNotification::class, 'notifiable');
```

This is the same as doing

```php
\Bouncer::ownedVia(DatabaseNotification::class, function ($model, $authority) {
    if ($model->notifiable_id !== $authority->id) {
        return false;
    }
            
    if ($model->notifiable_type !== get_class($authority)) {
        return false;
    }
            
    return true;
});
```