### PR TITLE
Add ability to override the which class to use for users in the Models class.

### DIFF
--- a/src/Bouncer.php
+++ b/src/Bouncer.php
@@ -408,4 +408,15 @@ class Bouncer
     {
         return Container::getInstance()->make($abstract, $parameters);
     }
+
+    /**
+     * Set the class to use for the user relation model.
+     *
+     * @param  string|object  $class
+     * @return void
+     */
+    public static function setUserClass($class)
+    {
+        Models::setUserClass($class);
+    }
 }

--- a/src/Database/Models.php
+++ b/src/Database/Models.php
@@ -3,7 +3,6 @@
 namespace Silber\Bouncer\Database;
 
 use Closure;
-use App\User;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Database\Eloquent\Model;
 
@@ -38,6 +37,13 @@ class Models
     protected static $tables = [];
 
     /**
+     * The class name for the user model.
+     *
+     * @var string
+     */
+    protected static $userClass = \App\User::class;
+
+    /**
      * Set the model to be used for abilities.
      *
      * @param  string  $model
@@ -67,7 +73,9 @@ class Models
      */
     public static function setUsersModel($model)
     {
-        static::$models[User::class] = $model;
+        $userclass = static::getUserClass();
+
+        static::$models[$userclass] = $model;
     }
 
     /**
@@ -217,7 +225,9 @@ class Models
      */
     public static function user(array $attributes = [])
     {
-        return static::make(User::class, $attributes);
+        $userclass = static::getUserClass();
+
+        return static::make($userclass, $attributes);
     }
 
     /**
@@ -273,5 +283,30 @@ class Models
         $segments = explode('\\', $class);
 
         return end($segments);
+    }
+
+    /**
+     * Get the class to use for the user model.
+     *
+     * @return string
+     */
+    public static function getUserClass()
+    {
+        return static::$userClass;
+    }
+
+    /**
+     * Set the class to use for the user model.
+     *
+     * @param  string|object  $class
+     * @return void
+     */
+    public static function setUserClass($class)
+    {
+        if ( ! is_string($class)) {
+            $class = get_class($class);
+        }
+
+        static::$userClass = $class;
     }
 }

--- a/src/Database/Models.php
+++ b/src/Database/Models.php
@@ -303,7 +303,7 @@ class Models
      */
     public static function setUserClass($class)
     {
-        if ( ! is_string($class)) {
+        if (! is_string($class)) {
             $class = get_class($class);
         }
 

--- a/tests/OverrideUserModelTest.php
+++ b/tests/OverrideUserModelTest.php
@@ -1,0 +1,28 @@
+<?php
+
+use Silber\Bouncer\Database\Models;
+
+class OverrideUserModelTest extends BaseTestCase
+{
+    public function testModelsUsesAppUserByDefault()
+    {
+        $this->assertEquals('App\User', Models::getUserClass());
+    }
+
+    public function testCanOverrideModelsUserClassWithString()
+    {
+        Models::setUserClass(AnotherUserClass::class);
+
+        $this->assertEquals('AnotherUserClass', Models::getUserClass());
+    }
+
+    public function testCanOverrideModelsUserClassWithObject()
+    {
+        Models::setUserClass(new AnotherUserClass);
+
+        $this->assertEquals('AnotherUserClass', Models::getUserClass());
+    }
+}
+
+class AnotherUserClass
+{}

--- a/tests/OverrideUserModelTest.php
+++ b/tests/OverrideUserModelTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Silber\Bouncer\Bouncer;
 use Silber\Bouncer\Database\Models;
 
 class OverrideUserModelTest extends BaseTestCase
@@ -19,6 +20,20 @@ class OverrideUserModelTest extends BaseTestCase
     public function testCanOverrideModelsUserClassWithObject()
     {
         Models::setUserClass(new AnotherUserClass);
+
+        $this->assertEquals('AnotherUserClass', Models::getUserClass());
+    }
+
+    public function testCanOverrideModelsUserClassFromBouncerWithString()
+    {
+        Bouncer::setUserClass(AnotherUserClass::class);
+
+        $this->assertEquals('AnotherUserClass', Models::getUserClass());
+    }
+
+    public function testCanOverrideModelsUserClassFromBouncerWithObject()
+    {
+        Bouncer::setUserClass(new AnotherUserClass);
 
         $this->assertEquals('AnotherUserClass', Models::getUserClass());
     }


### PR DESCRIPTION
It is bad practice to hard reference the `App` namespace in packages made for Laravel. Developers can change the namespace. Also, developers may want to use a different class for users. If they do, your package will not work. This fixes these issues. Tests included.