### PR TITLE
Proper morph column when using custom model

### DIFF
--- a/src/Database/Concerns/HasAbilities.php
+++ b/src/Database/Concerns/HasAbilities.php
@@ -24,7 +24,9 @@ trait HasAbilities
         return $this->morphToMany(
             Models::classname(Ability::class),
             'entity',
-            Models::table('permissions')
+            Models::table('permissions'),
+            null,
+            'ability_id'
         );
     }
 

--- a/src/Database/Concerns/HasRoles.php
+++ b/src/Database/Concerns/HasRoles.php
@@ -23,7 +23,9 @@ trait HasRoles
         return $this->morphToMany(
             Models::classname(Role::class),
             'entity',
-            Models::table('assigned_roles')
+            Models::table('assigned_roles'),
+            null,
+            'role_id'
         );
     }
 


### PR DESCRIPTION
Hello!

I am using custom Ability and Role model just as described in documentation.
Also I use custom table names.

**Service provider**
```
    public function boot()
    {
        Bouncer::tables([
            'abilities' => 'acl_abilities',
            'roles' => 'acl_roles',
            'assigned_roles' => 'acl_assigned_roles',
            'permissions' => 'acl_permissions',
        ]);

        Bouncer::useAbilityModel(MyAbility::class);
        Bouncer::useRoleModel(MyRole::class);
    }
```

**MyAbility**
```
<?php

namespace App;

use Silber\Bouncer\Database\Ability;

class MyAbility extends Ability
{
}
```

**MyRole**
```
<?php

namespace App;

use Silber\Bouncer\Database\Role;

class MyRole extends Role
{
}
```

But I get error if I try to get user roles
```
$roles = $user->roles;
```

error
```
SQLSTATE[42703]: Undefined column: 7 ERROR: column acl_assigned_roles.my_role_id does not exist
```

My attempt to fix this is by providing $otherKey for morphToMany in HasRoles and HasAbilities.

Is this the correct way or did I do something wrong and there is no need for a fix?

Essentially what I'm trying to achieve is admin panel where I can assign roles to a user, but I need to retrieve all available roles + user assigned roles.
But I'm also using laravelcollective/html Form::model() in my blade view and I need to extend Role model so that I can return array with abilities for my form checkbox loop.