### PR TITLE
Support PHPUnit versions 5 and 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "illuminate/console": "5.1.20 - 5.5",
         "illuminate/events": "5.1.20 - 5.5",
         "mockery/mockery": "^0.9.5",
-        "phpunit/phpunit": "^4.8.35",
+        "phpunit/phpunit": "4.8.35 - 6.5",
         "larapack/dd": "^1.1"
     },
     "suggest": {

--- a/tests/AbilitiesForModelsTest.php
+++ b/tests/AbilitiesForModelsTest.php
@@ -79,10 +79,11 @@ class AbilitiesForModelsTest extends BaseTestCase
         $this->assertTrue($bouncer->can('edit', $user2));
     }
 
+    /**
+     * @expectedException InvalidArgumentException
+     */
     public function test_allowing_on_non_existent_model_throws()
     {
-        $this->setExpectedException('InvalidArgumentException');
-
         $user1 = User::create();
         $user2 = new User;
 


### PR DESCRIPTION
I've added `PHPUnit` versions 5 and 6 support. I just need to use the `@expectedException` notation instead of the `setExpectedException` method, as it was removed in `PHPUnit 6`.