### PR TITLE
use Models::classname() when running registerMorphs

### DIFF
--- a/src/BouncerServiceProvider.php
+++ b/src/BouncerServiceProvider.php
@@ -113,8 +113,8 @@ class BouncerServiceProvider extends ServiceProvider
     protected function registerMorphs()
     {
         Relation::morphMap([
-            \Silber\Bouncer\Database\Role::class,
-            \Silber\Bouncer\Database\Ability::class,
+            Models::classname(\Silber\Bouncer\Database\Role::class),
+            Models::classname(\Silber\Bouncer\Database\Ability::class),
         ]);
     }
 


### PR DESCRIPTION
I am using:

Silber\Bouncer\Database\Models::setAbilitiesModel(MyAbility::class);
Silber\Bouncer\Database\Models::setRolesModel(MyRole::class);

but the BouncerServiceProvider is overwriting my custom values for Relation::morphMap()

ie, 

'roles' => MyRole::class

is being replaced by:

'roles' => Silber\Bouncer\Database\Role