### PR TITLE
Abilities not matched with case-sensitive keys

### DIFF
--- a/src/Clipboard.php
+++ b/src/Clipboard.php
@@ -213,8 +213,9 @@ class Clipboard implements ClipboardContract
         ];
 
         if ($model->exists) {
-            $abilities[] = "{$ability}-{$type}-{$model->getKey()}";
-            $abilities[] = "*-{$type}-{$model->getKey()}";
+            $key = strtolower($model->getKey());
+            $abilities[] = "{$ability}-{$type}-{$key}";
+            $abilities[] = "*-{$type}-{$key}";
         }
 
         return $abilities;


### PR DESCRIPTION
When the model keys contain uppercase chars, the abilities won't be matches because identifiers are always lowercase in laravel.