### PR TITLE
Adding typecasts for attributes

### DIFF
--- a/src/Database/Ability.php
+++ b/src/Database/Ability.php
@@ -21,6 +21,7 @@ class Ability extends Model
      * @var array
      */
     protected $casts = [
+        'id' => 'int',
         'only_owned' => 'boolean',
     ];
 

--- a/src/Database/Ability.php
+++ b/src/Database/Ability.php
@@ -16,6 +16,15 @@ class Ability extends Model
     protected $fillable = ['name', 'title'];
 
     /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'only_owned' => 'boolean',
+    ];
+
+    /**
      * Constructor.
      *
      * @param array  $attributes

--- a/src/Database/Role.php
+++ b/src/Database/Role.php
@@ -20,7 +20,11 @@ class Role extends Model
      *
      * @var array
      */
-    protected $casts = ['level' => 'int'];
+    protected $casts = [
+        'id' => 'int',
+        'entity_id' => 'int',
+        'level' => 'int',
+    ];
 
     /**
      * Constructor.


### PR DESCRIPTION
I ran into the issue that the properties were returned as strings from the database. (But only on the dedicated server at Siteground, not in localhost).

So I added typecasts fro non string attributes.

Is there a downside of adding these kind of typecasts?

-----
This might/will break custom UUID integrations into Bouncer, so users that use UUID have to override the `$cast` attribute