### PR TITLE
Escaped the whereRaw querys to allow special characters in table names

### DIFF
--- a/src/Database/Queries/Abilities.php
+++ b/src/Database/Queries/Abilities.php
@@ -41,7 +41,7 @@ class Abilities
 
             $query->from($roles)
                   ->join($permissions, $roles.'.id', '=', $permissions.'.entity_id')
-                  ->whereRaw("{$prefix}{$permissions}.ability_id = {$prefix}{$abilities}.id")
+                  ->whereRaw("`{$prefix}{$permissions}`.`ability_id` = `{$prefix}{$abilities}`.`id`")
                   ->where($permissions.".forbidden", ! $allowed)
                   ->where($permissions.".entity_type", Models::role()->getMorphClass());
 
@@ -92,7 +92,7 @@ class Abilities
 
             $query->from($table)
                   ->join($pivot, "{$table}.{$authority->getKeyName()}", '=', $pivot.'.entity_id')
-                  ->whereRaw("{$prefix}{$pivot}.role_id = {$prefix}{$roles}.id")
+                  ->whereRaw("`{$prefix}{$pivot}`.`role_id` = `{$prefix}{$roles}`.`id`")
                   ->where($pivot.'.entity_type', $authority->getMorphClass())
                   ->where("{$table}.{$authority->getKeyName()}", $authority->getKey());
 
@@ -118,7 +118,7 @@ class Abilities
 
             $query->from($table)
                   ->join($permissions, "{$table}.{$authority->getKeyName()}", '=', $permissions.'.entity_id')
-                  ->whereRaw("{$prefix}{$permissions}.ability_id = {$prefix}{$abilities}.id")
+                  ->whereRaw("`{$prefix}{$permissions}`.`ability_id` = `{$prefix}{$abilities}`.`id`")
                   ->where("{$permissions}.entity_type", $authority->getMorphClass())
                   ->where("{$permissions}.forbidden", ! $allowed)
                   ->where("{$table}.{$authority->getKeyName()}", $authority->getKey());

--- a/src/Database/Queries/Roles.php
+++ b/src/Database/Queries/Roles.php
@@ -76,7 +76,7 @@ class Roles
 
             $query->from($table)
                   ->join($pivot, $key, '=', $pivot.'.entity_id')
-                  ->whereRaw("{$prefix}{$pivot}.role_id = {$prefix}{$roles}.id")
+                  ->whereRaw("`{$prefix}{$pivot}`.`role_id` = `{$prefix}{$roles}`.`id`")
                   ->where("{$pivot}.entity_type", $model->getMorphClass())
                   ->whereIn($key, $keys);
 


### PR DESCRIPTION
When using custom table names with restricted characters (for instance :: in our project) the queries fail because whereRaw does not escape the table and column names.
This PR escapes the table and column names. 