### PR TITLE
Temporary fix for incorrect role class name

### DIFF
--- a/src/Database/Queries/Abilities.php
+++ b/src/Database/Queries/Abilities.php
@@ -54,7 +54,7 @@ class Abilities
                   ->join($permissions, $roles.'.id', '=', $permissions.'.entity_id')
                   ->whereRaw("{$prefix}{$permissions}.ability_id = {$prefix}{$abilities}.id")
                   ->where($permissions.".forbidden", ! $allowed)
-                  ->where($permissions.".entity_type", Models::role()->getMorphClass());
+                  ->where($permissions.".entity_type", Models::classname(\Silber\Bouncer\Database\Role::class));
 
             Models::scope()->applyToModelQuery($query, $roles);
             Models::scope()->applyToRelationQuery($query, $permissions);


### PR DESCRIPTION
Related to issue #306 
After some intense digging, I might have found the problem. Whenever I run more than one phpunit test at once, Bouncer failes to fetch the list of abilities for current authenticated user. This **only** happens when using a custom role model with `Bouncer::useRoleModel(Role::class);`.
When using the custom role model, the `getMorphClass()` function of laravels `HasRelationships.php` returns the key `roles` instead of the actual class name (but only starting at the second test while running phpunit!).
Because of that, Bouncers `getRoleConstraint()` query failes to find the abilities since the tables `entitiy_type` column contains the custom role models class name instead of the returned `roles` string from the morph map.
I am not entirely sure why you used `Models::role()->getMorphClass()` since I did not fully understand the concept yet. However, my change to this line eliminates the error for now while passing your unit tests.