### PR TITLE
Use `Schema` facade in migration file.

### DIFF
--- a/migrations/create_bouncer_tables.php
+++ b/migrations/create_bouncer_tables.php
@@ -2,6 +2,7 @@
 
 use Silber\Bouncer\Database\Models;
 
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 


### PR DESCRIPTION
In my application, I commented Schema alias

```php
'aliases' => [
    // 'Schema' => Illuminate\Support\Facades\Schema::class,
],
```

in `config/app.php`.

So I suggest adding `Schema` facade using into migration file.

I'm not sure if this is normal, but it's working for me. And I found this in migration stubs of laravel source:

<https://github.com/laravel/framework/blob/73d45d534c213fb73dfb77a46faa5336163c2efc/src/Illuminate/Database/Migrations/stubs/blank.stub#L3>