### PR TITLE
Use Bouncers clipboard instead of new instance

### DIFF
--- a/src/BouncerServiceProvider.php
+++ b/src/BouncerServiceProvider.php
@@ -163,7 +163,7 @@ class BouncerServiceProvider extends ServiceProvider
     {
         $gate = $this->app->make(Gate::class);
 
-        $clipboard = $this->app->make(Clipboard::class);
+        $clipboard = $this->app->make(Bouncer::class)->getClipboard();
 
         $clipboard->registerAt($gate);
     }


### PR DESCRIPTION
This PR is hopefully meant to be more of a discussion point rather than a fix as I might be missing something.

When trying to register Bouncer to run after policies on a fresh install with `Bouncer::runAfterPolicies()` in `AppServiceProvider` it has no effect.

Looks like to me a new clipboard is used at various stages rather than using the clipboard defined on the Bouncer instance.

So I'd say you'd either need to call `registerAt` on the same clipboard instance or bind a clipboard instance within the container.