### PR TITLE
Run the before or end callback with the current clipboard

### DIFF
--- a/src/BaseClipboard.php
+++ b/src/BaseClipboard.php
@@ -76,7 +76,7 @@ abstract class BaseClipboard implements Contracts\Clipboard
      * @param  mixed  $additional
      * @return bool|null
      */
-    protected function runBeforeCallback($authority, $ability, $arguments = [], $additional = null)
+    public function runBeforeCallback($authority, $ability, $arguments = [], $additional = null)
     {
         if ($this->slot != 'before') {
             return;
@@ -107,7 +107,7 @@ abstract class BaseClipboard implements Contracts\Clipboard
      * @param  array|null  $arguments
      * @return bool|null
      */
-    protected function runAfterCallback($authority, $ability, $result, $arguments = null)
+    public function runAfterCallback($authority, $ability, $result, $arguments = null)
     {
         if (! is_null($result)) {
             return $result;

--- a/src/BouncerServiceProvider.php
+++ b/src/BouncerServiceProvider.php
@@ -163,9 +163,17 @@ class BouncerServiceProvider extends ServiceProvider
     {
         $gate = $this->app->make(Gate::class);
 
-        $clipboard = $this->app->make(Contracts\Clipboard::class);
+        $gate->before(function () {
+            return call_user_func_array([
+                $this->app->make(Contracts\Clipboard::class), 'runBeforeCallback'
+            ], func_get_args());
+        });
 
-        $clipboard->registerAt($gate);
+        $gate->after(function () {
+            return call_user_func_array([
+                $this->app->make(Contracts\Clipboard::class), 'runAfterCallback'
+            ], func_get_args());
+        });
     }
 
     /**


### PR DESCRIPTION
Idea to fix https://github.com/JosephSilber/bouncer/issues/347 

As the Clipboard can be swapped after being registered, I think it is important the gate gets it from the container instead of using the one that was registered at the beginning.