### PR TITLE
Use custom table names for indexes

### DIFF
--- a/migrations/create_bouncer_tables.php
+++ b/migrations/create_bouncer_tables.php
@@ -37,7 +37,7 @@ class CreateBouncerTables extends Migration
 
             $table->unique(
                 ['name', 'scope'],
-                'roles_name_unique'
+                $table->getTable() . '_name_unique'
             );
         });
 
@@ -51,7 +51,7 @@ class CreateBouncerTables extends Migration
 
             $table->index(
                 ['entity_id', 'entity_type', 'scope'],
-                'assigned_roles_entity_index'
+                $table->getTable() . '_entity_index'
             );
 
             $table->foreign('role_id')
@@ -68,7 +68,7 @@ class CreateBouncerTables extends Migration
 
             $table->index(
                 ['entity_id', 'entity_type', 'scope'],
-                'permissions_entity_index'
+                $table->getTable() . '_entity_index'
             );
 
             $table->foreign('ability_id')


### PR DESCRIPTION
Sometimes you prefix table names because of naming conflicts. 

Currently the prefix for the index names in bouncer's migration file are hard coded and the migration brakes in case of conflicting index names.

In my case I installed a different package that also uses the table name `roles` and adds a unique constraint `roles_name_unique`, so when I try to migrate Bouncer of course it fails: 

> `relation "roles_name_unique" already exists`

With this proposed change, if for example I prefix the roles table with `silber` then the unique index on the name column would would be `silber_roles_name_unique` and there would be no conflicts.