### PR TITLE
Changed WhereRaw functions to Laravel 5.2's WhereColumn.

### DIFF
--- a/src/Database/Queries/Abilities.php
+++ b/src/Database/Queries/Abilities.php
@@ -53,7 +53,7 @@ class Abilities
 
             $query->from($roles)
                   ->join($permissions, $roles.'.id', '=', $permissions.'.entity_id')
-                  ->whereRaw("{$prefix}{$permissions}.ability_id = {$prefix}{$abilities}.id")
+                  ->whereColumn("{$prefix}{$permissions}.ability_id", "{$prefix}{$abilities}.id")
                   ->where($permissions.".forbidden", ! $allowed)
                   ->where($permissions.".entity_type", Models::role()->getMorphClass());
 
@@ -105,7 +105,7 @@ class Abilities
 
             $query->from($table)
                   ->join($pivot, "{$table}.{$authority->getKeyName()}", '=', $pivot.'.entity_id')
-                  ->whereRaw("{$prefix}{$pivot}.role_id = {$prefix}{$roles}.id")
+                  ->whereColumn("{$prefix}{$pivot}.role_id", "{$prefix}{$roles}.id")
                   ->where($pivot.'.entity_type', $authority->getMorphClass())
                   ->where("{$table}.{$authority->getKeyName()}", $authority->getKey());
 
@@ -131,7 +131,7 @@ class Abilities
 
             $query->from($table)
                   ->join($permissions, "{$table}.{$authority->getKeyName()}", '=', $permissions.'.entity_id')
-                  ->whereRaw("{$prefix}{$permissions}.ability_id = {$prefix}{$abilities}.id")
+                  ->whereColumn("{$prefix}{$permissions}.ability_id", "{$prefix}{$abilities}.id")
                   ->where("{$permissions}.forbidden", ! $allowed)
                   ->where("{$permissions}.entity_type", $authority->getMorphClass())
                   ->where("{$table}.{$authority->getKeyName()}", $authority->getKey());
@@ -155,7 +155,7 @@ class Abilities
             $prefix      = Models::prefix();
 
             $query->from($permissions)
-                  ->whereRaw("{$prefix}{$permissions}.ability_id = {$prefix}{$abilities}.id")
+                  ->whereColumn("{$prefix}{$permissions}.ability_id", "{$prefix}{$abilities}.id")
                   ->where("{$permissions}.forbidden", ! $allowed)
                   ->whereNull('entity_id');
 

--- a/src/Database/Queries/Roles.php
+++ b/src/Database/Queries/Roles.php
@@ -76,7 +76,7 @@ class Roles
 
             $query->from($table)
                   ->join($pivot, $key, '=', $pivot.'.entity_id')
-                  ->whereRaw("{$prefix}{$pivot}.role_id = {$prefix}{$roles}.id")
+                  ->whereColumn("{$prefix}{$pivot}.role_id", "{$prefix}{$roles}.id")
                   ->where("{$pivot}.entity_type", $model->getMorphClass())
                   ->whereIn($key, $keys);
 


### PR DESCRIPTION
Hi Joseph it's me again.

You once said version 1.0 would require Laravel 5.5+. So here is my WhereRaw to WhereColumn fix again. 

The main reason I keep pushing this change is when you use characters in your table prefix that should be escaped, the whereRaw approach breaks down. Also WhereColumn has been around since Laravel 5.2 so should be decent backwards compatibility imho. 