### PR TITLE
Make the bouncer when booting service provider

### DIFF
--- a/src/BouncerServiceProvider.php
+++ b/src/BouncerServiceProvider.php
@@ -47,12 +47,15 @@ class BouncerServiceProvider extends ServiceProvider
      */
     protected function registerBouncer()
     {
-        $bouncer = Bouncer::make()
-                ->withClipboard(new CachedClipboard(new ArrayStore))
-                ->withGate($this->app->make(Gate::class))
-                ->create();
-
-        $this->app->instance(Bouncer::class, $bouncer);
+        $this->app->singleton(
+            Bouncer::class,
+            function () {
+                return Bouncer::make()
+                    ->withClipboard(new CachedClipboard(new ArrayStore))
+                    ->withGate($this->app->make(Gate::class))
+                    ->create();
+            }
+        );
     }
 
     /**

--- a/src/BouncerServiceProvider.php
+++ b/src/BouncerServiceProvider.php
@@ -33,6 +33,7 @@ class BouncerServiceProvider extends ServiceProvider
         $this->registerMorphs();
         $this->setTablePrefix();
         $this->setUserModel();
+        $this->app->make(Bouncer::class);
 
         if ($this->runningInConsole()) {
             $this->publishMiddleware();

--- a/src/BouncerServiceProvider.php
+++ b/src/BouncerServiceProvider.php
@@ -47,15 +47,12 @@ class BouncerServiceProvider extends ServiceProvider
      */
     protected function registerBouncer()
     {
-        $this->app->singleton(
-            Bouncer::class,
-            function () {
-                return Bouncer::make()
-                    ->withClipboard(new CachedClipboard(new ArrayStore))
-                    ->withGate($this->app->make(Gate::class))
-                    ->create();
-            }
-        );
+        $this->app->singleton(Bouncer::class, function () {
+            return Bouncer::make()
+                ->withClipboard(new CachedClipboard(new ArrayStore))
+                ->withGate($this->app->make(Gate::class))
+                ->create();
+        });
     }
 
     /**


### PR DESCRIPTION
This is a follow up to #403 .

The patch at #403 fixed the issue of loading service provider, but it did not register the bouncer properly at the clipboard. By making it at boot, it is registered at the clipboard so it can be used.