### PR TITLE
Fix "typo" in $casts

### DIFF
--- a/src/Database/Ability.php
+++ b/src/Database/Ability.php
@@ -22,6 +22,7 @@ class Ability extends Model
      */
     protected $casts = [
         'id' => 'int',
+        'entity_id' => 'int',
         'only_owned' => 'boolean',
     ];
 

--- a/src/Database/Role.php
+++ b/src/Database/Role.php
@@ -22,7 +22,6 @@ class Role extends Model
      */
     protected $casts = [
         'id' => 'int',
-        'entity_id' => 'int',
         'level' => 'int',
     ];
 


### PR DESCRIPTION
'entity_id' is a column in abilities table, not roles. This PR puts its cast to the right model.