### PR TITLE
Update Abilities.php

### DIFF
--- a/src/Database/Queries/Abilities.php
+++ b/src/Database/Queries/Abilities.php
@@ -18,7 +18,7 @@ class Abilities
      */
     public static function forAuthority(Model $authority, $allowed = true)
     {
-        return Models::ability()->where(function ($query) use ($authority, $allowed) {
+        return Models::ability()->on($authority->getConnectionName())->where(function ($query) use ($authority, $allowed) {
             $query->whereExists(static::getRoleConstraint($authority, $allowed));
             $query->orWhereExists(static::getAuthorityConstraint($authority, $allowed));
             $query->orWhereExists(static::getEveryoneConstraint($allowed));


### PR DESCRIPTION
Make query on database where $authority (in most cases the auth()->user()) is created

At the moment if Bouncer is used on multi tenant application this query looks up in default DB (which is given inside config('database.default')).

With this change nothing would break and it it will make the query in proper DB.