### PR TITLE
Allow for $user->whereIs(['admin', 'manager'])

### DIFF
--- a/src/Database/Queries/Roles.php
+++ b/src/Database/Queries/Roles.php
@@ -11,12 +11,12 @@ class Roles
      * Constrain the given query by the provided role.
      *
      * @param  \Illuminate\Database\Eloquent\Builder  $query
-     * @param  string  $role
+     * @param  string|array  $roles
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    public function constrainWhereIs($query, $role)
+    public function constrainWhereIs($query, $roles)
     {
-        $roles = array_slice(func_get_args(), 1);
+        $roles = is_array($roles) ? $roles : array_slice(func_get_args(), 1);
 
         return $query->whereHas('roles', function ($query) use ($roles) {
             $query->whereIn('name', $roles);


### PR DESCRIPTION
Allows to pass in array of roles, not just attributes, makes things a little easier when dealing w/ arrays and not having to use call_user_func_array('User::whereIs', ['admin', 'manager'])->get() which looks clunky.