### PR TITLE
Test only specific version of Laravel 6 and PHP 7.4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        laravel: [6.15.0]
+        laravel: [6.14.0]
         php: [7.4]
       fail-fast: false
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,8 +17,8 @@ jobs:
 
     strategy:
       matrix:
-        laravel: [6.0.0]
-        php: [7.4]
+        laravel: [^6.0]
+        php: [7.4.0]
       fail-fast: false
 
     name: Laravel ${{ matrix.laravel }}, PHP ${{ matrix.php }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        laravel: [6.14.0]
+        laravel: [6.7.0]
         php: [7.4]
       fail-fast: false
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        laravel: [6.3.0]
+        laravel: [6.0.0]
         php: [7.4]
       fail-fast: false
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,8 +17,8 @@ jobs:
 
     strategy:
       matrix:
-        laravel: [6.*]
-        php: [7.2, 7.3, 7.4]
+        laravel: [6.15.0]
+        php: [7.4]
       fail-fast: false
 
     name: Laravel ${{ matrix.laravel }}, PHP ${{ matrix.php }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        laravel: [6.7.0]
+        laravel: [6.3.0]
         php: [7.4]
       fail-fast: false
 


### PR DESCRIPTION
Since a recent version of Laravel broke our tests, I'm trying to isolate exactly which version it was.