### PR TITLE
Remove the getClipboardInstance() methods

### DIFF
--- a/src/Database/Concerns/Authorizable.php
+++ b/src/Database/Concerns/Authorizable.php
@@ -16,7 +16,9 @@ trait Authorizable
      */
     public function can($ability, $model = null)
     {
-        return $this->getClipboardInstance()->check($this, $ability, $model);
+        return Container::getInstance()
+            ->make(Clipboard::class)
+            ->check($this, $ability, $model);
     }
 
     /**
@@ -41,17 +43,5 @@ trait Authorizable
     public function cannot($ability, $model = null)
     {
         return $this->cant($ability, $model);
-    }
-
-    /**
-     * Get an instance of the bouncer's clipboard.
-     *
-     * @return \Silber\Bouncer\Contracts\Clipboard
-     */
-    protected function getClipboardInstance()
-    {
-        $container = Container::getInstance() ?: new Container;
-
-        return $container->make(Clipboard::class);
     }
 }

--- a/src/Database/Concerns/HasAbilities.php
+++ b/src/Database/Concerns/HasAbilities.php
@@ -49,7 +49,9 @@ trait HasAbilities
      */
     public function getAbilities()
     {
-        return $this->getClipboardInstance()->getAbilities($this);
+        return Container::getInstance()
+            ->make(Clipboard::class)
+            ->getAbilities($this);
     }
 
     /**
@@ -59,7 +61,9 @@ trait HasAbilities
      */
     public function getForbiddenAbilities()
     {
-        return $this->getClipboardInstance()->getAbilities($this, false);
+        return Container::getInstance()
+            ->make(Clipboard::class)
+            ->getAbilities($this, false);
     }
 
     /**
@@ -132,17 +136,5 @@ trait HasAbilities
         (new UnforbidsAbilities($this))->to($ability, $model);
 
         return $this;
-    }
-
-    /**
-     * Get an instance of the bouncer's clipboard.
-     *
-     * @return \Silber\Bouncer\Contracts\Clipboard
-     */
-    protected function getClipboardInstance()
-    {
-        $container = Container::getInstance() ?: new Container;
-
-        return $container->make(Clipboard::class);
     }
 }

--- a/src/Database/Concerns/HasRoles.php
+++ b/src/Database/Concerns/HasRoles.php
@@ -48,7 +48,9 @@ trait HasRoles
      */
     public function getRoles()
     {
-        return $this->getClipboardInstance()->getRoles($this);
+        return Container::getInstance()
+            ->make(Clipboard::class)
+            ->getRoles($this);
     }
 
     /**
@@ -87,9 +89,9 @@ trait HasRoles
     {
         $roles = func_get_args();
 
-        $clipboard = $this->getClipboardInstance();
-
-        return $clipboard->checkRole($this, $roles, 'or');
+        return Container::getInstance()
+            ->make(Clipboard::class)
+            ->checkRole($this, $roles, 'or');
     }
 
     /**
@@ -115,9 +117,9 @@ trait HasRoles
     {
         $roles = func_get_args();
 
-        $clipboard = $this->getClipboardInstance();
-
-        return $clipboard->checkRole($this, $roles, 'not');
+        return Container::getInstance()
+            ->make(Clipboard::class)
+            ->checkRole($this, $roles, 'not');
     }
 
     /**
@@ -143,9 +145,9 @@ trait HasRoles
     {
         $roles = func_get_args();
 
-        $clipboard = $this->getClipboardInstance();
-
-        return $clipboard->checkRole($this, $roles, 'and');
+        return Container::getInstance()
+            ->make(Clipboard::class)
+            ->checkRole($this, $roles, 'and');
     }
 
     /**
@@ -191,17 +193,5 @@ trait HasRoles
             [new RolesQuery, 'constrainWhereIsNot'],
             func_get_args()
         );
-    }
-
-    /**
-     * Get an instance of the bouncer's clipboard.
-     *
-     * @return \Silber\Bouncer\Contracts\Clipboard
-     */
-    protected function getClipboardInstance()
-    {
-        $container = Container::getInstance() ?: new Container;
-
-        return $container->make(Clipboard::class);
     }
 }

--- a/src/Database/Concerns/IsRole.php
+++ b/src/Database/Concerns/IsRole.php
@@ -16,9 +16,7 @@ use Illuminate\Database\Eloquent\Model;
 
 trait IsRole
 {
-    use HasAbilities, Authorizable {
-        HasAbilities::getClipboardInstance insteadof Authorizable;
-    }
+    use HasAbilities, Authorizable;
 
     /**
      * Boot the is role trait.

--- a/src/Database/HasRolesAndAbilities.php
+++ b/src/Database/HasRolesAndAbilities.php
@@ -7,7 +7,5 @@ use Silber\Bouncer\Database\Concerns\HasAbilities;
 
 trait HasRolesAndAbilities
 {
-    use HasRoles, HasAbilities {
-        HasRoles::getClipboardInstance insteadof HasAbilities;
-    }
+    use HasRoles, HasAbilities;
 }

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -202,9 +202,7 @@ abstract class BaseTestCase extends TestCase
 
 class User extends Eloquent
 {
-    use Authorizable, HasRolesAndAbilities {
-        Authorizable::getClipboardInstance insteadof HasRolesAndAbilities;
-    }
+    use Authorizable, HasRolesAndAbilities;
 
     protected $table = 'users';
 


### PR DESCRIPTION
Since Laravel 5.3, [`Container::getInstance()` always returns an instance of the container](https://github.com/laravel/framework/pull/13111); if an instance hadn't been registered as a singleton, it registers a new one on the fly.

Since we no longer support older versions of Laravel, we can inline the `getInstance` call wherever we use it. This removes the need for precedence rules - both in Bouncer itself, and for [userland code](https://github.com/JosephSilber/bouncer/issues/465#issuecomment-588985901).