### PR TITLE
Fix #372 since whereColumn automatically prepend table prefix

### DIFF
--- a/src/BouncerServiceProvider.php
+++ b/src/BouncerServiceProvider.php
@@ -32,7 +32,6 @@ class BouncerServiceProvider extends ServiceProvider
     public function boot()
     {
         $this->registerMorphs();
-        $this->setTablePrefix();
         $this->setUserModel();
 
         $this->registerAtGate();
@@ -76,32 +75,6 @@ class BouncerServiceProvider extends ServiceProvider
     protected function registerMorphs()
     {
         Models::updateMorphMap();
-    }
-
-    /**
-     * Set the table prefix for Bouncer's tables.
-     *
-     * @return void
-     */
-    protected function setTablePrefix()
-    {
-        if ($prefix = $this->getTablePrefix()) {
-            Models::setPrefix($prefix);
-        }
-    }
-
-    /**
-     * Get the configured table prefix.
-     *
-     * @return string|null
-     */
-    protected function getTablePrefix()
-    {
-        $config = $this->app->config['database'];
-
-        $connection = Arr::get($config, 'default');
-
-        return Arr::get($config, "connections.{$connection}.prefix");
     }
 
     /**

--- a/src/Database/Models.php
+++ b/src/Database/Models.php
@@ -14,13 +14,6 @@ use Silber\Bouncer\Contracts\Scope as ScopeContract;
 class Models
 {
     /**
-     * The prefix for all tables.
-     *
-     * @var string
-     */
-    protected static $prefix = '';
-
-    /**
      * Map of bouncer's models.
      *
      * @var array
@@ -101,17 +94,6 @@ class Models
     }
 
     /**
-     * Set the prefix for the tables.
-     *
-     * @param  string  $prefix
-     * @return void
-     */
-    public static function setPrefix($prefix)
-    {
-        static::$prefix = $prefix;
-    }
-
-    /**
      * Get a custom table name mapping for the given table.
      *
      * @param  string  $table
@@ -124,16 +106,6 @@ class Models
         }
 
         return $table;
-    }
-
-    /**
-     * Get the prefix for the tables.
-     *
-     * @return string
-     */
-    public static function prefix()
-    {
-        return static::$prefix;
     }
 
     /**

--- a/src/Database/Queries/Abilities.php
+++ b/src/Database/Queries/Abilities.php
@@ -49,11 +49,10 @@ class Abilities
             $permissions = Models::table('permissions');
             $abilities   = Models::table('abilities');
             $roles       = Models::table('roles');
-            $prefix      = Models::prefix();
 
             $query->from($roles)
                   ->join($permissions, $roles.'.id', '=', $permissions.'.entity_id')
-                  ->whereColumn("{$prefix}{$permissions}.ability_id", "{$prefix}{$abilities}.id")
+                  ->whereColumn("{$permissions}.ability_id", "{$abilities}.id")
                   ->where($permissions.".forbidden", ! $allowed)
                   ->where($permissions.".entity_type", Models::role()->getMorphClass());
 
@@ -101,11 +100,10 @@ class Abilities
             $pivot  = Models::table('assigned_roles');
             $roles  = Models::table('roles');
             $table  = $authority->getTable();
-            $prefix = Models::prefix();
 
             $query->from($table)
                   ->join($pivot, "{$table}.{$authority->getKeyName()}", '=', $pivot.'.entity_id')
-                  ->whereColumn("{$prefix}{$pivot}.role_id", "{$prefix}{$roles}.id")
+                  ->whereColumn("{$pivot}.role_id", "{$roles}.id")
                   ->where($pivot.'.entity_type', $authority->getMorphClass())
                   ->where("{$table}.{$authority->getKeyName()}", $authority->getKey());
 
@@ -127,11 +125,10 @@ class Abilities
             $permissions = Models::table('permissions');
             $abilities   = Models::table('abilities');
             $table       = $authority->getTable();
-            $prefix      = Models::prefix();
 
             $query->from($table)
                   ->join($permissions, "{$table}.{$authority->getKeyName()}", '=', $permissions.'.entity_id')
-                  ->whereColumn("{$prefix}{$permissions}.ability_id", "{$prefix}{$abilities}.id")
+                  ->whereColumn("{$permissions}.ability_id", "{$abilities}.id")
                   ->where("{$permissions}.forbidden", ! $allowed)
                   ->where("{$permissions}.entity_type", $authority->getMorphClass())
                   ->where("{$table}.{$authority->getKeyName()}", $authority->getKey());
@@ -152,10 +149,9 @@ class Abilities
         return function ($query) use ($allowed) {
             $permissions = Models::table('permissions');
             $abilities   = Models::table('abilities');
-            $prefix      = Models::prefix();
 
             $query->from($permissions)
-                  ->whereColumn("{$prefix}{$permissions}.ability_id", "{$prefix}{$abilities}.id")
+                  ->whereColumn("{$permissions}.ability_id", "{$abilities}.id")
                   ->where("{$permissions}.forbidden", ! $allowed)
                   ->whereNull('entity_id');
 

--- a/src/Database/Queries/Roles.php
+++ b/src/Database/Queries/Roles.php
@@ -66,11 +66,10 @@ class Roles
             $key    = "{$table}.{$model->getKeyName()}";
             $pivot  = Models::table('assigned_roles');
             $roles  = Models::table('roles');
-            $prefix = Models::prefix();
 
             $query->from($table)
                   ->join($pivot, $key, '=', $pivot.'.entity_id')
-                  ->whereColumn("{$prefix}{$pivot}.role_id", "{$prefix}{$roles}.id")
+                  ->whereColumn("{$pivot}.role_id", "{$roles}.id")
                   ->where("{$pivot}.entity_type", $model->getMorphClass())
                   ->whereIn($key, $keys);
 


### PR DESCRIPTION
This is related to #372 

**Problem trying to solve**
`whereColumn` method already prepend table prefixes for columns.
This PR removes the duplicate prefix as it's currently produces db errors.

**Scenario**
PHP v7.4.3
Laravel v7.1.3
Bouncer v1.0.0-rc.7

Config (with database table prefix)

I didn't try Bouncer v1.0.0-rc.7 with Laravel v6, but currently the `whereColumn` method seems to be consistent with other database query grammer, and it's being prefixed as expected.