### PR TITLE
Fixes #527 - Use custom table resolver for compatibility with other auth drivers

### DIFF
--- a/src/Database/Models.php
+++ b/src/Database/Models.php
@@ -35,6 +35,13 @@ class Models
     protected static $tables = [];
 
     /**
+     * The defined custom table resolvers.
+     *
+     * @var array
+     */
+    protected static $customTableResolvers = [];
+
+    /**
      * The model scoping instance.
      *
      * @var \Silber\Bouncer\Database\Scope\Scope
@@ -77,7 +84,9 @@ class Models
     {
         static::$models[User::class] = $model;
 
-        static::$tables['users'] = static::user()->getTable();
+        static::$customTableResolvers['users'] = function () {
+            static::user()->getTable();
+        };
     }
 
     /**
@@ -101,6 +110,10 @@ class Models
      */
     public static function table($table)
     {
+        if (isset(static::$customTableResolvers[$table])) {
+            return static::$customTableResolvers[$table]();
+        }
+
         if (isset(static::$tables[$table])) {
             return static::$tables[$table];
         }

--- a/src/Database/Models.php
+++ b/src/Database/Models.php
@@ -85,7 +85,7 @@ class Models
         static::$models[User::class] = $model;
 
         static::$customTableResolvers['users'] = function () {
-            static::user()->getTable();
+            return static::user()->getTable();
         };
     }
 


### PR DESCRIPTION
This provides the ability to successfully customize the user model, as the database table is only resolved when needed via the `table` method. This pattern is used in the Laravel core, such as `Illuminate\Auth\AuthManager::$customCreators`.

Once all of the applications service providers `boot()`, the user model will be overridden and its model will be used.