### PR TITLE
Added support for PHP 8 and upgraded to PHPUnit 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "files": ["tests/helpers.php"]
     },
     "require": {
-        "php": "^7.2",
+        "php": "^7.2|^8.0",
         "illuminate/auth": "^6.0|^7.0|^8.0",
         "illuminate/cache": "^6.0|^7.0|^8.0",
         "illuminate/container": "^6.0|^7.0|^8.0",
@@ -39,7 +39,7 @@
     "require-dev": {
         "illuminate/console": "^6.0|^7.0|^8.0",
         "illuminate/events": "^6.0|^7.0|^8.0",
-        "phpunit/phpunit": "^8.0",
+        "phpunit/phpunit": "^8.0|^9.0",
         "larapack/dd": "^1.1"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -39,8 +39,9 @@
     "require-dev": {
         "illuminate/console": "^6.0|^7.0|^8.0",
         "illuminate/events": "^6.0|^7.0|^8.0",
-        "phpunit/phpunit": "^8.0|^9.0",
-        "larapack/dd": "^1.1"
+        "phpunit/phpunit": "^9.0",
+        "larapack/dd": "^1.1",
+        "phpspec/prophecy-phpunit": "^2.0"
     },
     "suggest": {
         "illuminate/console": "Allows running the bouncer:clean artisan command",

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "files": ["tests/helpers.php"]
     },
     "require": {
-        "php": "^7.2|^8.0",
+        "php": "^7.3|^8.0",
         "illuminate/auth": "^6.0|^7.0|^8.0",
         "illuminate/cache": "^6.0|^7.0|^8.0",
         "illuminate/container": "^6.0|^7.0|^8.0",

--- a/tests/Concerns/TestsConsoleCommands.php
+++ b/tests/Concerns/TestsConsoleCommands.php
@@ -6,6 +6,7 @@ use Prophecy\Argument;
 use Illuminate\Console\Command;
 use Illuminate\Console\OutputStyle;
 use Prophecy\Prophecy\ObjectProphecy;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\NullOutput;
 use Illuminate\Contracts\Foundation\Application;
@@ -13,6 +14,8 @@ use Symfony\Component\Console\Formatter\OutputFormatter;
 
 trait TestsConsoleCommands
 {
+    use ProphecyTrait;
+
     /**
      * Get a prophesy for the laravel application class.
      *


### PR DESCRIPTION
In order to add support for PHP 8, PHPUnit had to be upgraded to version 9.
This introduced some warnings during the tests.

```
There were 4 warnings:

1) Silber\Bouncer\Tests\CleanCommandTest::the_orphaned_flag
PHPUnit\Framework\TestCase::prophesize() is deprecated and will be removed in PHPUnit 10. Please use the trait provided by phpspec/prophecy-phpunit.

2) Silber\Bouncer\Tests\CleanCommandTest::the_orphaned_flag_with_no_orphaned_abilities
PHPUnit\Framework\TestCase::prophesize() is deprecated and will be removed in PHPUnit 10. Please use the trait provided by phpspec/prophecy-phpunit.

3) Silber\Bouncer\Tests\CleanCommandTest::the_missing_flag
PHPUnit\Framework\TestCase::prophesize() is deprecated and will be removed in PHPUnit 10. Please use the trait provided by phpspec/prophecy-phpunit.

4) Silber\Bouncer\Tests\CleanCommandTest::no_flags
PHPUnit\Framework\TestCase::prophesize() is deprecated and will be removed in PHPUnit 10. Please use the trait provided by phpspec/prophecy-phpunit.
```

These are also fixed with this PR, but now PHPUnit 9 is required.
Tests run 100% fine on PHP 7.4.13 and 8.0.0

PHPUnit 9 had PHP version 7.3 required as base version, so this had to be updated as well