### PR TITLE
A fix for #446, #566

### DIFF
--- a/src/Console/CleanCommand.php
+++ b/src/Console/CleanCommand.php
@@ -162,7 +162,6 @@ class CleanCommand extends Command
 
         return Models::ability()
                      ->whereNotNull("{$table}.entity_id")
-                     ->where("{$table}.entity_id", '!=', '*')
                      ->where("{$table}.entity_type", '!=', '*');
     }
 


### PR DESCRIPTION
`entity_id` comparison to `*` is invalid (postgres would say: _Invalid text representation: 7 ERROR:  invalid input syntax for type bigint: "*"_).

`whereNotNull` above already takes care of the intent.

#446, #566