### PR TITLE
Use typesafe checks when creating the ability identifier

### DIFF
--- a/src/Database/Concerns/IsAbility.php
+++ b/src/Database/Concerns/IsAbility.php
@@ -185,11 +185,11 @@ trait IsAbility
     {
         $slug = $this->attributes['name'];
 
-        if ($this->attributes['entity_type']) {
+        if ($this->attributes['entity_type'] !== null) {
             $slug .= '-'.$this->attributes['entity_type'];
         }
 
-        if ($this->attributes['entity_id']) {
+        if ($this->attributes['entity_id'] !== null) {
             $slug .= '-'.$this->attributes['entity_id'];
         }
 

--- a/tests/ForbidTest.php
+++ b/tests/ForbidTest.php
@@ -190,6 +190,23 @@ class ForbidTest extends BaseTestCase
      * @test
      * @dataProvider bouncerProvider
      */
+    function forbid_an_ability_on_everything_with_zero_id($provider)
+    {
+        list($bouncer, $user1, $user2, $user3) = $provider(3);
+
+        $user2->setAttribute($user2->getKeyName(), 0);
+
+        $bouncer->allow($user1)->everything();
+        $bouncer->forbid($user1)->to('edit', $user2);
+
+        $this->assertTrue($bouncer->cannot('edit', $user2));
+        $this->assertTrue($bouncer->can('edit', $user3));
+    }
+
+    /**
+     * @test
+     * @dataProvider bouncerProvider
+     */
     function forbidding_and_unforbidding_an_ability_for_everyone($provider)
     {
         list($bouncer, $user) = $provider();


### PR DESCRIPTION
**Use case**

Ability attributes:

- `name` = `update-somemodel`
- `entity_type` = `App\SomeModel`
- `entity_id` = `0`

**Expected identifier attribute value**

`update-somemodel-app-somemodel-0`

**Actual identifier attribute value**
_without using typesafe checks_

`update-somemodel-app-somemodel`

Since

```php
if ($this->attributes['entity_id'])
```

will return `false` for `0` values.

**Long story short**

Using `0` as *id value* for an entity leads to wrong permissions checks (e.g. *forbid to update concrete model XY with id = `0`*)