### PR TITLE
Remove null checks and allow it to be queried

### DIFF
--- a/src/Database/Scope/Scope.php
+++ b/src/Database/Scope/Scope.php
@@ -93,7 +93,7 @@ class Scope implements ScopeContract
      */
     public function applyToModel(Model $model)
     {
-        if (! $this->onlyScopeRelations && ! is_null($this->scope)) {
+        if (! $this->onlyScopeRelations) {
             $model->scope = $this->scope;
         }
 
@@ -165,8 +165,8 @@ class Scope implements ScopeContract
             $query->whereNull("{$table}.scope");
 
             if (! is_null($this->scope)) {
-                $query->orWhere("{$table}.scope", $this->scope)            
-            }      
+                $query->orWhere("{$table}.scope", $this->scope)
+            }
         });
     }
 

--- a/src/Database/Scope/Scope.php
+++ b/src/Database/Scope/Scope.php
@@ -93,7 +93,7 @@ class Scope implements ScopeContract
      */
     public function applyToModel(Model $model)
     {
-        if (! $this->onlyScopeRelations && ! is_null($this->scope)) {
+        if (! $this->onlyScopeRelations) {
             $model->scope = $this->scope;
         }
 
@@ -109,7 +109,7 @@ class Scope implements ScopeContract
      */
     public function applyToModelQuery($query, $table = null)
     {
-        if (is_null($this->scope) || $this->onlyScopeRelations) {
+        if ($this->onlyScopeRelations) {
             return $query;
         }
 
@@ -129,10 +129,6 @@ class Scope implements ScopeContract
      */
     public function applyToRelationQuery($query, $table)
     {
-        if (is_null($this->scope)) {
-            return $query;
-        }
-
         return $this->applyToQuery($query, $table);
     }
 
@@ -165,10 +161,12 @@ class Scope implements ScopeContract
      */
     protected function applyToQuery($query, $table)
     {
-        return $query->where(function ($query) use ($table) {
-            $query->where("{$table}.scope", $this->scope)
-                  ->orWhereNull("{$table}.scope");
-        });
+        return is_null($this->scope)
+            ? $query->whereNull("{$table}.scope")
+            : $query->where(function ($query) use ($table) {
+                    $query->where("{$table}.scope", $this->scope)
+                          ->orWhereNull("{$table}.scope");
+                });
     }
 
     /**

--- a/src/Database/Scope/Scope.php
+++ b/src/Database/Scope/Scope.php
@@ -93,7 +93,7 @@ class Scope implements ScopeContract
      */
     public function applyToModel(Model $model)
     {
-        if (! $this->onlyScopeRelations) {
+        if (! $this->onlyScopeRelations && ! is_null($this->scope)) {
             $model->scope = $this->scope;
         }
 
@@ -165,7 +165,7 @@ class Scope implements ScopeContract
             $query->whereNull("{$table}.scope");
 
             if (! is_null($this->scope)) {
-                $query->orWhere("{$table}.scope", $this->scope)
+                $query->orWhere("{$table}.scope", $this->scope);
             }
         });
     }

--- a/src/Database/Scope/Scope.php
+++ b/src/Database/Scope/Scope.php
@@ -93,7 +93,7 @@ class Scope implements ScopeContract
      */
     public function applyToModel(Model $model)
     {
-        if (! $this->onlyScopeRelations) {
+        if (! $this->onlyScopeRelations && ! is_null($this->scope)) {
             $model->scope = $this->scope;
         }
 

--- a/tests/MultiTenancyTest.php
+++ b/tests/MultiTenancyTest.php
@@ -346,6 +346,9 @@ class MultiTenancyTest extends BaseTestCase
 
         $bouncer->scope()->to(2);
         $this->assertFalse($bouncer->is($user)->an('admin'));
+
+        $bouncer->scope()->to(null);
+        $this->assertFalse($bouncer->is($user)->an('admin'));
     }
 
     /**

--- a/tests/MultiTenancyTest.php
+++ b/tests/MultiTenancyTest.php
@@ -140,6 +140,26 @@ class MultiTenancyTest extends BaseTestCase
      * @test
      * @dataProvider bouncerProvider
      */
+    function scoped_abilities_do_not_work_when_unscoped($provider)
+    {
+        list($bouncer, $user) = $provider();
+
+        $bouncer->scope()->to(1);
+        $bouncer->allow($user)->to(['write', 'read']);
+
+        $this->assertTrue($bouncer->can('write'));
+        $this->assertTrue($bouncer->can('read'));
+        $this->assertEquals(2, $user->abilities()->count());
+
+        $bouncer->scope()->to(null);
+        $this->assertFalse($bouncer->can('write'));
+        $this->assertFalse($bouncer->can('read'));
+    }
+
+    /**
+     * @test
+     * @dataProvider bouncerProvider
+     */
     function relation_queries_are_properly_scoped($provider)
     {
         list($bouncer, $user) = $provider();


### PR DESCRIPTION
Fix #607. This has the expected behavior and not so eager to grant permissions when you may not want them to be granted.