### PR TITLE
add column id of pivot record in relations

### DIFF
--- a/src/Database/Concerns/HasAbilities.php
+++ b/src/Database/Concerns/HasAbilities.php
@@ -42,7 +42,7 @@ trait HasAbilities
             Models::classname(Ability::class),
             'entity',
             Models::table('permissions')
-        )->withPivot('forbidden', 'scope');
+        )->withPivot('id', 'forbidden', 'scope');
 
         return Models::scope()->applyToRelation($relation);
     }

--- a/src/Database/Concerns/HasRoles.php
+++ b/src/Database/Concerns/HasRoles.php
@@ -41,7 +41,7 @@ trait HasRoles
             Models::classname(Role::class),
             'entity',
             Models::table('assigned_roles')
-        )->withPivot('scope');
+        )->withPivot('id', 'scope');
 
         return Models::scope()->applyToRelation($relation);
     }

--- a/src/Database/Concerns/IsAbility.php
+++ b/src/Database/Concerns/IsAbility.php
@@ -155,7 +155,7 @@ trait IsAbility
             Models::classname(Role::class),
             'entity',
             Models::table('permissions')
-        )->withPivot('forbidden', 'scope');
+        )->withPivot('id', 'forbidden', 'scope');
 
         return Models::scope()->applyToRelation($relation);
     }
@@ -171,7 +171,7 @@ trait IsAbility
             Models::classname(User::class),
             'entity',
             Models::table('permissions')
-        )->withPivot('forbidden', 'scope');
+        )->withPivot('id', 'forbidden', 'scope');
 
         return Models::scope()->applyToRelation($relation);
     }

--- a/src/Database/Concerns/IsRole.php
+++ b/src/Database/Concerns/IsRole.php
@@ -52,7 +52,7 @@ trait IsRole
             Models::classname(User::class),
             'entity',
             Models::table('assigned_roles')
-        )->withPivot('scope');
+        )->withPivot('id', 'scope');
 
         return Models::scope()->applyToRelation($relation);
     }


### PR DESCRIPTION
I am working with this package and I wanted to have audit processes, I need to know the id of the records created in the `assigned_roles` and `permissions` pivot tables. Particularly I am using the package https://github.com/spatie/laravel-activitylog, but it is not important since the pivot relationships are not with models which cannot be listened for events.

That's why I was trying to perform manual audit trails when attaching and detaching users to roles for example. For that I need the ids of the mentioned tables. These tables do not have assigned models and in case you want to retrieve this information you should make a query using the "DB" facade (this is how these records are registered, for example in `Conductors\AssignsRoles` in `$this->newPivotTableQuery()->insert()`.

Another alternative to using the DB is to use the relationships of the `Role` and `Ability` models, but in these `morphToMany` information about the id of the pivot table does not come.
We can see this quickly with tinker:
```php
$role = \Silber\Bouncer\Database\Role::query()->whereHas('users')->with(['users'])->first();
$role->users->first()->pivot;
```

The change adds the `id` columns in the pivot relationships of the `Role` and `Ability` models as well as the traits to apply to the `User` model.
