### PR TITLE
check preventAccessingMissingAttributes user_id default owned

### DIFF
--- a/src/Database/Models.php
+++ b/src/Database/Models.php
@@ -186,6 +186,7 @@ class Models
     public static function isOwnedBy(Model $authority, Model $model)
     {
         $type = get_class($model);
+        $isDefaultAttribute = false;
 
         if (isset(static::$ownership[$type])) {
             $attribute = static::$ownership[$type];
@@ -193,9 +194,10 @@ class Models
             $attribute = static::$ownership['*'];
         } else {
             $attribute = strtolower(static::basename($authority)).'_id';
+            $isDefaultAttribute = true;
         }
 
-        return static::isOwnedVia($attribute, $authority, $model);
+        return static::isOwnedVia($attribute, $authority, $model, $isDefaultAttribute);
     }
 
     /**
@@ -204,12 +206,17 @@ class Models
      * @param  string|\Closure  $attribute
      * @param  \Illuminate\Database\Eloquent\Model  $authority
      * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  bool  $isDefaultAttribute
      * @return bool
      */
-    protected static function isOwnedVia($attribute, Model $authority, Model $model)
+    protected static function isOwnedVia($attribute, Model $authority, Model $model, $isDefaultAttribute = false)
     {
         if ($attribute instanceof Closure) {
             return $attribute($model, $authority);
+        }
+
+        if ($isDefaultAttribute && !array_key_exists($attribute, $model->getAttributes())) {
+            return false;
         }
 
         return $authority->getKey() == $model->{$attribute};


### PR DESCRIPTION
According to this article, it is recommended to use these checks to avoid errors during the development of an application in Laravel.
[https://planetscale.com/blog/laravels-safety-mechanisms](https://planetscale.com/blog/laravels-safety-mechanisms)

When trying to add `\Illuminate\Database\Eloquent\Model::preventAccessingMissingAttributes();` an exception is thrown when trying to check some permission of a specific model and it does not have an owned callback or column defined. 
When undefined it tries to look up the attribute (`{model}_id`, for example `user_id`). In the vast majority of models that attribute (column) does not exist and the `isOwnedVia` function returns false, but activating the check option, when trying to access `user_id` an exception is thrown because the attribute does not exist.
This PR checks if the attribute exists only when the attribute has not been defined correctly (ie default).

