### PR TITLE
Reset scope when create new bouncer instance

### DIFF
--- a/src/Bouncer.php
+++ b/src/Bouncer.php
@@ -524,9 +524,9 @@ class Bouncer
     /**
      * Get the model scoping instance.
      *
-     * @return mixed
+     * @return Scope
      */
-    public function scope(?Scope $scope = null)
+    public function scope(?Scope $scope = null): Scope
     {
         return Models::scope($scope);
     }

--- a/src/Database/Models.php
+++ b/src/Database/Models.php
@@ -109,9 +109,9 @@ class Models
     /**
      * Get or set the model scoping instance.
      *
-     * @return mixed
+     * @return ScopeContract
      */
-    public static function scope(?ScopeContract $scope = null)
+    public static function scope(?ScopeContract $scope = null): ScopeContract
     {
         if (! is_null($scope)) {
             return static::$scope = $scope;

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -74,6 +74,8 @@ class Factory
 
         $bouncer = (new Bouncer($guard))->setGate($gate);
 
+        $bouncer->scope()->remove();
+
         if ($this->registerAtGate) {
             $guard->registerAt($gate);
         }

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -6,6 +6,7 @@ use Illuminate\Auth\Access\Gate;
 use Illuminate\Container\Container;
 use PHPUnit\Framework\Attributes\Test;
 use Silber\Bouncer\Bouncer;
+use Silber\Bouncer\Database\Models;
 use Workbench\App\Models\User;
 
 class FactoryTest extends BaseTestCase
@@ -57,5 +58,16 @@ class FactoryTest extends BaseTestCase
 
         $this->assertTrue($bouncer->can('create-bouncers'));
         $this->assertTrue($bouncer->cannot('delete-bouncers'));
+    }
+
+    #[Test]
+    public function can_create_bouncer_instance_and_reset_scope()
+    {
+        Models::scope()->to(1);
+        $this->assertNotNull(Models::scope()->get());
+
+        $bouncer = Bouncer::create();
+
+        $this->assertNull(Models::scope()->get());
     }
 }


### PR DESCRIPTION
Hello team!

the Scope is persistent between several application initialization (typically during tests).
the scope is defined as a static value in Silber\Bouncer\Database\Models and is not reset when bouncer service is initialized.
Due to this, the scope is not reset between tests.

So the solution that I propose is to reset scope when create new bouncer instance

linked to issue [643](https://github.com/JosephSilber/bouncer/issues/643)