### PR TITLE
Disable missing attributes check on model via isOwnedBy check

### DIFF
--- a/src/Database/Models.php
+++ b/src/Database/Models.php
@@ -192,7 +192,6 @@ class Models
             $attribute = strtolower(static::basename($authority)).'_id';
         }
 
-
         $isOwnedVia = static::isOwnedVia($attribute, $authority, $model);
         $model::preventAccessingMissingAttributes($preventsAccessingMissingAttributes);
         return $isOwnedVia;

--- a/src/Database/Models.php
+++ b/src/Database/Models.php
@@ -180,6 +180,8 @@ class Models
      */
     public static function isOwnedBy(Model $authority, Model $model)
     {
+        $preventsAccessingMissingAttributes = $model::preventsAccessingMissingAttributes();
+        $model::preventAccessingMissingAttributes(false);
         $type = get_class($model);
 
         if (isset(static::$ownership[$type])) {
@@ -190,7 +192,10 @@ class Models
             $attribute = strtolower(static::basename($authority)).'_id';
         }
 
-        return static::isOwnedVia($attribute, $authority, $model);
+
+        $isOwnedVia = static::isOwnedVia($attribute, $authority, $model);
+        $model::preventAccessingMissingAttributes($preventsAccessingMissingAttributes);
+        return $isOwnedVia;
     }
 
     /**


### PR DESCRIPTION
This pull request references your idea on this pull request: #620 

Hope it is going to be pulled as soon as possible. Because I do not want to turn off my shouldBeStrict checks globally